### PR TITLE
feat: multiple responses & better metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,10 @@ Create a `BorderConfiguration` using the `createBorder()` function. This functio
 - `body` - Any Zod schema
 - `params` - A string record of Zod schemas where the key is the name of your URL parameters
 - `query` - A string record of Zod schemas
-- `response` - Any zod schema
+- `responses` - Array of response objects with the following properties
+  - `name` - A name for the response (used for OpenAPI model)
+  - `status` - The HTTP status code
+  - `body` - A Zod schema for the response body (optional)
 
 To make use of the newly created `BorderConfiguration` you decorate your controller endpoint with the `@UseBorder()` decorator. This will in turn validate the incoming request and outgoing response with the supplied schemas in the `BorderConfiguration`.
 
@@ -79,9 +82,26 @@ const PostBorder = createBorder({
   params: {
     someParam: z.string(),
   },
-  response: z.object({
-    publicData: z.string(),
-  }),
+  responses: [
+    {
+      name: "Some response",
+      status: 200,
+      body: z.object({
+        publicData: z.string(),
+      }),
+    },
+    {
+      name: "Some error",
+      status: 400,
+      body: z.object({
+        error: z.string(),
+      }),
+    },
+    {
+      name: "Some other error",
+      status: 500,
+    }
+  ],
 });
 
 @Controller()
@@ -99,7 +119,7 @@ export class SampleController {
     // { someParam: string; }
     @Param() params: InferParams<typeof PostBorder>
   ): // Will be typed as:
-  // { publicData: string; }
+  // { publicData: string; } | { error: string; }
   Promise<InferResponse<typeof PostBorder>> {
     return {
       publicData: "Hello world",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qte/nest-border-patrol",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "description": "",
   "main": "./dist/index",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qte/nest-border-patrol",
-  "version": "0.2.4",
+  "version": "0.3.0-alpha.1",
   "description": "",
   "main": "./dist/index",
   "files": [
@@ -46,6 +46,7 @@
     "zod": "^3.21.4"
   },
   "dependencies": {
+    "@abitia/zod-dto": "^0.4.0",
     "@anatine/zod-openapi": "^2.1.0",
     "zod-to-ts": "^1.1.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qte/nest-border-patrol",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "description": "",
   "main": "./dist/index",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qte/nest-border-patrol",
-  "version": "0.3.0-alpha.3",
+  "version": "0.3.0-alpha.4",
   "description": "",
   "main": "./dist/index",
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,6 +1,13 @@
 lockfileVersion: '6.0'
 
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
 dependencies:
+  '@abitia/zod-dto':
+    specifier: ^0.4.0
+    version: 0.4.0(@nestjs/common@10.0.5)(@nestjs/swagger@7.1.1)(zod@3.21.4)
   '@anatine/zod-openapi':
     specifier: ^2.1.0
     version: 2.1.0(openapi3-ts@4.1.2)(zod@3.21.4)
@@ -74,6 +81,18 @@ devDependencies:
     version: 3.21.4
 
 packages:
+
+  /@abitia/zod-dto@0.4.0(@nestjs/common@10.0.5)(@nestjs/swagger@7.1.1)(zod@3.21.4):
+    resolution: {integrity: sha512-luuFHmllxgHhnTSjhXGZwnPkCeHSQ/OdtRh1BfDnsonSJkaAz1YpQ4Go9iilukQBEinJrkePSySIBEU1DUtHtw==}
+    peerDependencies:
+      '@nestjs/common': 8.x
+      '@nestjs/swagger': 5.1.x
+      zod: ^3.0.2
+    dependencies:
+      '@nestjs/common': 10.0.5(reflect-metadata@0.1.13)(rxjs@7.8.0)
+      '@nestjs/swagger': 7.1.1(@nestjs/common@10.0.5)(@nestjs/core@10.0.5)(reflect-metadata@0.1.13)
+      zod: 3.21.4
+    dev: false
 
   /@ampproject/remapping@2.2.1:
     resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
@@ -711,7 +730,6 @@ packages:
   /@lukeed/csprng@1.1.0:
     resolution: {integrity: sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==}
     engines: {node: '>=8'}
-    dev: true
 
   /@mole-inc/bin-wrapper@8.0.1:
     resolution: {integrity: sha512-sTGoeZnjI8N4KS+sW2AN95gDBErhAguvkw/tWdCjeM8bvxpz5lqrnd0vOJABA1A+Ic3zED7PYoLP/RANLgVotA==}
@@ -745,7 +763,6 @@ packages:
       rxjs: 7.8.0
       tslib: 2.6.0
       uid: 2.0.2
-    dev: true
 
   /@nestjs/core@10.0.5(@nestjs/common@10.0.5)(@nestjs/platform-express@10.0.5)(@nestjs/websockets@10.1.3)(reflect-metadata@0.1.13)(rxjs@7.8.0):
     resolution: {integrity: sha512-9A8nixBfE33TWAmmWvNoxdmHrRmHJY0oO3O4Iue0FVkawWJc0YOhSqdNs87McwvKE4InJMI7GVv01NYMEROdPA==}
@@ -778,7 +795,6 @@ packages:
       uid: 2.0.2
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /@nestjs/mapped-types@2.0.2(@nestjs/common@10.0.5)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-V0izw6tWs6fTp9+KiiPUbGHWALy563Frn8X6Bm87ANLRuE46iuBMD5acKBDP5lKL/75QFvrzSJT7HkCbB0jTpg==}
@@ -795,7 +811,6 @@ packages:
     dependencies:
       '@nestjs/common': 10.0.5(reflect-metadata@0.1.13)(rxjs@7.8.0)
       reflect-metadata: 0.1.13
-    dev: true
 
   /@nestjs/platform-express@10.0.5(@nestjs/common@10.0.5)(@nestjs/core@10.0.5):
     resolution: {integrity: sha512-mNHXiVsfJsknjfgC1kEUM82ynvkCxod5tNOEAnEcZ7UpPWy5dsxspq+ynt6RF6bd/3AD6sZoxApwqAKbcQnzxw==}
@@ -812,7 +827,6 @@ packages:
       tslib: 2.6.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@nestjs/platform-ws@10.1.3(@nestjs/common@10.0.5)(@nestjs/websockets@10.1.3)(rxjs@7.8.0):
     resolution: {integrity: sha512-irGGpzkQ+9RofB1Ea0DEuq/abArAn+Myq9J1WtYDCdrFinAReh2vEN+NH+bdcu8m9u+SoD+z2XPvgEq6GDHK9g==}
@@ -856,7 +870,6 @@ packages:
       path-to-regexp: 3.2.0
       reflect-metadata: 0.1.13
       swagger-ui-dist: 5.1.0
-    dev: true
 
   /@nestjs/testing@10.0.5(@nestjs/common@10.0.5)(@nestjs/core@10.0.5)(@nestjs/platform-express@10.0.5):
     resolution: {integrity: sha512-TQcFOxR+kIibMbYg71yajic3289/Iw7B5LliYiZ4Pz36BZvU0TRMYqpxaGAlX/Srk0BCpP99ZHoofm8dqZKmxw==}
@@ -896,7 +909,6 @@ packages:
       reflect-metadata: 0.1.13
       rxjs: 7.8.0
       tslib: 2.6.1
-    dev: true
 
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -929,7 +941,6 @@ packages:
       node-fetch: 2.6.9
     transitivePeerDependencies:
       - encoding
-    dev: true
 
   /@sinclair/typebox@0.25.24:
     resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
@@ -1312,7 +1323,6 @@ packages:
     dependencies:
       mime-types: 2.1.35
       negotiator: 0.6.3
-    dev: true
 
   /ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -1338,7 +1348,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: true
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -1355,7 +1364,6 @@ packages:
 
   /append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
-    dev: true
 
   /arch@2.2.0:
     resolution: {integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==}
@@ -1369,11 +1377,9 @@ packages:
 
   /argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
-    dev: true
 
   /array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
-    dev: true
 
   /asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
@@ -1502,7 +1508,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /body-parser@1.20.2:
     resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
@@ -1522,7 +1527,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -1557,19 +1561,16 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: true
 
   /busboy@1.6.0:
     resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
     engines: {node: '>=10.16.0'}
     dependencies:
       streamsearch: 1.1.0
-    dev: true
 
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /cacheable-lookup@5.0.4:
     resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
@@ -1594,7 +1595,6 @@ packages:
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.2.0
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1630,7 +1630,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: true
 
   /char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -1681,7 +1680,6 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: true
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
@@ -1689,7 +1687,6 @@ packages:
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: true
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -1719,23 +1716,19 @@ packages:
       inherits: 2.0.4
       readable-stream: 2.3.8
       typedarray: 0.0.6
-    dev: true
 
   /consola@2.15.3:
     resolution: {integrity: sha512-9vAdYbHj6x2fLKC4+oPH0kFzY/orMZyG2Aj+kNylHxKGJ/Ed4dpNyAQYwJOdqO4zdM7XpVHmyejQDcQHrnuXbw==}
-    dev: true
 
   /content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
     engines: {node: '>= 0.6'}
     dependencies:
       safe-buffer: 5.2.1
-    dev: true
 
   /content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /convert-source-map@1.9.0:
     resolution: {integrity: sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==}
@@ -1747,12 +1740,10 @@ packages:
 
   /cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-    dev: true
 
   /cookie@0.5.0:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
@@ -1760,7 +1751,6 @@ packages:
 
   /core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
-    dev: true
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -1768,7 +1758,6 @@ packages:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    dev: true
 
   /cross-spawn@5.1.0:
     resolution: {integrity: sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==}
@@ -1796,7 +1785,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.0.0
-    dev: true
 
   /debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -1839,12 +1827,10 @@ packages:
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dev: true
 
   /detect-newline@3.1.0:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
@@ -1865,7 +1851,6 @@ packages:
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
-    dev: true
 
   /electron-to-chromium@1.4.369:
     resolution: {integrity: sha512-LfxbHXdA/S+qyoTEA4EbhxGjrxx7WK2h6yb5K2v0UCOufUKX+VZaHbl3svlzZfv9sGseym/g3Ne4DpsgRULmqg==}
@@ -1883,7 +1868,6 @@ packages:
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
@@ -1904,7 +1888,6 @@ packages:
 
   /escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
-    dev: true
 
   /escape-string-regexp@1.0.5:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
@@ -1930,7 +1913,6 @@ packages:
   /etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /execa@0.7.0:
     resolution: {integrity: sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==}
@@ -2020,7 +2002,6 @@ packages:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /ext-list@2.2.2:
     resolution: {integrity: sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==}
@@ -2054,7 +2035,6 @@ packages:
 
   /fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
-    dev: true
 
   /fastq@1.15.0:
     resolution: {integrity: sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==}
@@ -2111,7 +2091,6 @@ packages:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /find-up@4.1.0:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
@@ -2149,12 +2128,10 @@ packages:
   /forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /fresh@0.5.2:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
@@ -2170,7 +2147,6 @@ packages:
 
   /function-bind@1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
-    dev: true
 
   /gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -2188,7 +2164,6 @@ packages:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.3
-    dev: true
 
   /get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -2264,19 +2239,16 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: true
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
-    dev: true
 
   /has@1.0.3:
     resolution: {integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==}
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
-    dev: true
 
   /hexoid@1.0.0:
     resolution: {integrity: sha512-QFLV0taWQOZtvIRIAdBChesmogZrtuXvVWsFHZTk2SU+anspqZ2vMnoLg7IE1+Uk16N19APic1BuF8bC8c2m5g==}
@@ -2300,7 +2272,6 @@ packages:
       setprototypeof: 1.2.0
       statuses: 2.0.1
       toidentifier: 1.0.1
-    dev: true
 
   /http2-wrapper@1.0.3:
     resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
@@ -2320,7 +2291,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       safer-buffer: 2.1.2
-    dev: true
 
   /ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -2349,12 +2319,10 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-    dev: true
 
   /ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-    dev: true
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -2410,7 +2378,6 @@ packages:
 
   /isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
-    dev: true
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2465,7 +2432,6 @@ packages:
   /iterare@1.2.1:
     resolution: {integrity: sha512-RKYVTCjAnRthyJes037NX/IiqeidgN1xc3j1RjFfECFp28A1GVwK9nA+i0rJPaHqSZwygLzRnFlzUuHFoWWy+Q==}
     engines: {node: '>=6'}
-    dev: true
 
   /jest-changed-files@29.5.0:
     resolution: {integrity: sha512-IFG34IUMUaNBIxjQXF/iu7g6EcdMrGRRxaUSw92I/2g2YC6vCdTltl4nHvt7Ci5nSJwXIkCu8Ka1DKF+X7Z1Ag==}
@@ -2893,7 +2859,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
@@ -2948,7 +2913,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: true
 
   /lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -2991,11 +2955,9 @@ packages:
   /media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /merge-descriptors@1.0.1:
     resolution: {integrity: sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==}
-    dev: true
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -3009,7 +2971,6 @@ packages:
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /micromatch@4.0.5:
     resolution: {integrity: sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==}
@@ -3022,20 +2983,17 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
   /mime@1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -3066,18 +3024,15 @@ packages:
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-    dev: true
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
     dependencies:
       minimist: 1.2.8
-    dev: true
 
   /ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
-    dev: true
 
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -3085,7 +3040,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: true
 
   /multer@1.4.4-lts.1:
     resolution: {integrity: sha512-WeSGziVj6+Z2/MwQo3GvqzgR+9Uc+qt8SwHKh3gvNPiISKfsMfG4SvCOFYlxxgkXt7yIV2i1yczehm0EOKIxIg==}
@@ -3098,7 +3052,6 @@ packages:
       object-assign: 4.1.1
       type-is: 1.6.18
       xtend: 4.0.2
-    dev: true
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -3107,7 +3060,6 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /node-fetch@2.6.9:
     resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
@@ -3119,7 +3071,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: true
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -3156,23 +3107,19 @@ packages:
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /object-hash@3.0.0:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
-    dev: true
 
   /object-inspect@1.12.3:
     resolution: {integrity: sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==}
-    dev: true
 
   /on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
     dependencies:
       ee-first: 1.1.1
-    dev: true
 
   /once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -3249,7 +3196,6 @@ packages:
   /parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3277,11 +3223,9 @@ packages:
 
   /path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
-    dev: true
 
   /path-to-regexp@3.2.0:
     resolution: {integrity: sha512-jczvQbCUS7XmS7o+y1aEO9OBVFeZBQ1MDSEqmO7xSoPgOPoowY/SxLpZ6Vh97/8qHZOteiCKb7gkG9gA2ZUxJA==}
-    dev: true
 
   /peek-readable@5.0.0:
     resolution: {integrity: sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==}
@@ -3325,7 +3269,6 @@ packages:
 
   /process-nextick-args@2.0.1:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
-    dev: true
 
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
@@ -3341,7 +3284,6 @@ packages:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
-    dev: true
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -3363,7 +3305,6 @@ packages:
     engines: {node: '>=0.6'}
     dependencies:
       side-channel: 1.0.4
-    dev: true
 
   /qs@6.11.2:
     resolution: {integrity: sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==}
@@ -3384,7 +3325,6 @@ packages:
   /range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /raw-body@2.5.1:
     resolution: {integrity: sha512-qqJBtEyVgS0ZmPGdCFPWJ3FreoqvG4MVQln/kCgF7Olq95IbOp0/BWyMwbdtn4VTvkM8Y7khCQ2Xgk/tcrCXig==}
@@ -3394,7 +3334,6 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
   /raw-body@2.5.2:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
@@ -3404,7 +3343,6 @@ packages:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       unpipe: 1.0.0
-    dev: true
 
   /react-is@18.2.0:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
@@ -3420,7 +3358,6 @@ packages:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
-    dev: true
 
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
@@ -3440,7 +3377,6 @@ packages:
 
   /reflect-metadata@0.1.13:
     resolution: {integrity: sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==}
-    dev: true
 
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3498,19 +3434,15 @@ packages:
     resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
     dependencies:
       tslib: 2.5.0
-    dev: true
 
   /safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
-    dev: true
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: true
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-    dev: true
 
   /semver-regex@4.0.5:
     resolution: {integrity: sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==}
@@ -3556,7 +3488,6 @@ packages:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /serve-static@1.15.0:
     resolution: {integrity: sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==}
@@ -3568,11 +3499,9 @@ packages:
       send: 0.18.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
-    dev: true
 
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -3604,7 +3533,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.0
       object-inspect: 1.12.3
-    dev: true
 
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -3664,12 +3592,10 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
-    dev: true
 
   /string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -3692,7 +3618,6 @@ packages:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
     dependencies:
       safe-buffer: 5.1.2
-    dev: true
 
   /string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -3780,7 +3705,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: true
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
@@ -3796,7 +3720,6 @@ packages:
 
   /swagger-ui-dist@5.1.0:
     resolution: {integrity: sha512-c1KmAjuVODxw+vwkNLALQZrgdlBAuBbr2xSPfYrJgseEi7gFKcTvShysPmyuDI4kcUa1+5rFpjWvXdusKY74mg==}
-    dev: true
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -3826,7 +3749,6 @@ packages:
   /toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
-    dev: true
 
   /token-types@5.0.1:
     resolution: {integrity: sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==}
@@ -3838,7 +3760,6 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: true
 
   /trim-repeated@2.0.0:
     resolution: {integrity: sha512-QUHBFTJGdOwmp0tbOG505xAgOp/YliZP/6UgafFXYZ26WT1bvQmSMJUvkeVSASuJJHbqsFbynTvkd5W8RBTipg==}
@@ -3854,15 +3775,12 @@ packages:
 
   /tslib@2.5.0:
     resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
-    dev: true
 
   /tslib@2.6.0:
     resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
-    dev: true
 
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
-    dev: true
 
   /type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -3880,11 +3798,9 @@ packages:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-    dev: true
 
   /typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
-    dev: true
 
   /typescript@5.0.4:
     resolution: {integrity: sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==}
@@ -3896,12 +3812,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@lukeed/csprng': 1.1.0
-    dev: true
 
   /unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /update-browserslist-db@1.0.11(browserslist@4.21.5):
     resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
@@ -3916,12 +3830,10 @@ packages:
 
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-    dev: true
 
   /utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-    dev: true
 
   /v8-to-istanbul@9.1.0:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
@@ -3935,7 +3847,6 @@ packages:
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
-    dev: true
 
   /walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -3945,14 +3856,12 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: true
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: true
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -4006,7 +3915,6 @@ packages:
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
-    dev: true
 
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}

--- a/src/__test__/open-api/open-api.spec.ts
+++ b/src/__test__/open-api/open-api.spec.ts
@@ -33,7 +33,6 @@ describe("Open API generation", () => {
     expect(true).toBe(true);
     const parameters = swaggerDocument.paths["/test"]?.get?.parameters;
 
-    console.log(parameters);
     if (!parameters) {
       throw new Error("Parameters not set");
     }

--- a/src/__test__/validation/validation.controller.ts
+++ b/src/__test__/validation/validation.controller.ts
@@ -20,9 +20,15 @@ export const PostBorder = createBorder({
   params: {
     someParam: z.literal("correct"),
   },
-  response: z.object({
-    publicData: z.string(),
-  }),
+  responses: [
+    {
+      name: "Some response",
+      status: 200,
+      body: z.object({
+        publicData: z.string(),
+      }),
+    }
+  ]
 });
 
 @Controller({ path: "test" })

--- a/src/__test__/validation/validation.controller.ts
+++ b/src/__test__/validation/validation.controller.ts
@@ -23,7 +23,7 @@ export const PostBorder = createBorder({
   responses: [
     {
       name: "Some response",
-      status: 200,
+      status: 201,
       body: z.object({
         publicData: z.string(),
       }),

--- a/src/__test__/validation/without-filter.spec.ts
+++ b/src/__test__/validation/without-filter.spec.ts
@@ -104,6 +104,5 @@ describe("Validation without filter", () => {
   it("responds with 500 when data is missing from response", async () => {
     const response = await request(app.getHttpServer()).get(`/test/`);
     expect(response.status).toBe(500);
-    console.log(response.body);
   });
 });

--- a/src/border-patrol-core.module.ts
+++ b/src/border-patrol-core.module.ts
@@ -1,14 +1,13 @@
+import { patchNestjsSwagger } from '@abitia/zod-dto';
 import { DynamicModule, FactoryProvider, Global, Module } from "@nestjs/common";
 import {
   APP_FILTER,
-  DiscoveryModule,
-  DiscoveryService,
-  Reflector,
+  DiscoveryModule
 } from "@nestjs/core";
-import { ModuleAsyncOptions, ModuleOptions } from "./types";
+import { BorderPatrolExplorerService } from "./border-patrol-explorer.service";
 import { MODULE_OPTIONS_KEY } from "./border-patrol.constants";
 import { BorderPatrolExceptionFilter } from "./border-patrol.filter";
-import { BorderPatrolExplorerService } from "./border-patrol-explorer.service";
+import { ModuleAsyncOptions, ModuleOptions } from "./types";
 
 @Global()
 @Module({})
@@ -33,6 +32,8 @@ export class BorderPatrolCoreModule {
         return null;
       },
     };
+
+    patchNestjsSwagger();
 
     return {
       imports: [DiscoveryModule],

--- a/src/border-patrol.decorators.ts
+++ b/src/border-patrol.decorators.ts
@@ -6,7 +6,7 @@ import {
 } from "@nestjs/common";
 import { generateSchema } from "@anatine/zod-openapi";
 import { ApiBody, ApiOkResponse, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
-import { Banger, BorderConfiguration } from "./types";
+import { ApiResponseType, BorderConfiguration } from "./types";
 import { z } from "zod";
 import { BorderPatrolInterceptor } from "./border-patrol.interceptor";
 import { BorderPatrolPipe } from "./border-patrol.pipe";
@@ -17,7 +17,7 @@ export const UseBorder = <
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends Banger | undefined
+  TResponse extends ApiResponseType | undefined
 >(
   config: BorderConfiguration<TBody, TQuery, TParams, TResponse>
 ) => {

--- a/src/border-patrol.decorators.ts
+++ b/src/border-patrol.decorators.ts
@@ -5,7 +5,7 @@ import {
   UsePipes,
 } from "@nestjs/common";
 import { generateSchema } from "@anatine/zod-openapi";
-import { ApiBody, ApiOkResponse, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
+import { ApiBody, ApiOkResponse, ApiOperation, ApiOperationOptions, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
 import { ApiResponseType, BorderConfiguration } from "./types";
 import { z } from "zod";
 import { BorderPatrolInterceptor } from "./border-patrol.interceptor";
@@ -17,9 +17,10 @@ export const UseBorder = <
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends ApiResponseType | undefined
+  TResponse extends ApiResponseType | undefined,
+  TMetadata extends ApiOperationOptions | undefined
 >(
-  config: BorderConfiguration<TBody, TQuery, TParams, TResponse>
+  config: BorderConfiguration<TBody, TQuery, TParams, TResponse, TMetadata>
 ) => {
   const swaggerDecorators: MethodDecorator[] = [];
 
@@ -67,6 +68,9 @@ export const UseBorder = <
         })
       );
     });
+  }
+  if (config.meta) {
+    swaggerDecorators.push(ApiOperation(config.meta));
   }
 
   return applyDecorators(

--- a/src/border-patrol.decorators.ts
+++ b/src/border-patrol.decorators.ts
@@ -1,17 +1,17 @@
+import { createZodDto } from '@abitia/zod-dto';
+import { generateSchema } from "@anatine/zod-openapi";
 import {
   applyDecorators,
   SetMetadata,
   UseInterceptors,
   UsePipes,
 } from "@nestjs/common";
-import { generateSchema } from "@anatine/zod-openapi";
-import { ApiBody, ApiOkResponse, ApiOperation, ApiOperationOptions, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
-import { ApiResponseType, BorderConfiguration } from "./types";
+import { ApiBody, ApiOperation, ApiOperationOptions, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
 import { z } from "zod";
+import { BORDER_CONFIGURATION_KEY } from "./border-patrol.constants";
 import { BorderPatrolInterceptor } from "./border-patrol.interceptor";
 import { BorderPatrolPipe } from "./border-patrol.pipe";
-import { BORDER_CONFIGURATION_KEY } from "./border-patrol.constants";
-import { createZodDto } from '@abitia/zod-dto'
+import { ApiResponseType, BorderConfiguration } from "./types";
 
 export const UseBorder = <
   TBody extends z.ZodSchema | undefined,
@@ -27,15 +27,15 @@ export const UseBorder = <
   if (config.responses) {
     swaggerDecorators.push(...config.responses.map((response) => {
       if (!response.body) {
-        return ApiOkResponse({ status: response.status });
+        return ApiResponse({ status: response.status });
       }
 
-      const clazz = createZodDto(response.body);
-      Object.defineProperty(clazz, 'name', { value: response.name })
+      const dtoClass = createZodDto(response.body);
+      Object.defineProperty(dtoClass, 'name', { value: response.name })
 
       return ApiResponse({
         status: response.status,
-        type: clazz,
+        type: dtoClass,
       });
     }));
   }

--- a/src/border-patrol.decorators.ts
+++ b/src/border-patrol.decorators.ts
@@ -5,27 +5,38 @@ import {
   UsePipes,
 } from "@nestjs/common";
 import { generateSchema } from "@anatine/zod-openapi";
-import { ApiBody, ApiOkResponse, ApiParam, ApiQuery } from "@nestjs/swagger";
-import { BorderConfiguration } from "./types";
+import { ApiBody, ApiOkResponse, ApiParam, ApiQuery, ApiResponse } from "@nestjs/swagger";
+import { Banger, BorderConfiguration } from "./types";
 import { z } from "zod";
 import { BorderPatrolInterceptor } from "./border-patrol.interceptor";
 import { BorderPatrolPipe } from "./border-patrol.pipe";
 import { BORDER_CONFIGURATION_KEY } from "./border-patrol.constants";
+import { createZodDto } from '@abitia/zod-dto'
 
 export const UseBorder = <
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends z.ZodSchema | undefined
+  TResponse extends Banger | undefined
 >(
   config: BorderConfiguration<TBody, TQuery, TParams, TResponse>
 ) => {
   const swaggerDecorators: MethodDecorator[] = [];
 
-  if (config.response) {
-    swaggerDecorators.push(
-      ApiOkResponse({ schema: generateSchema(config.response) as any })
-    );
+  if (config.responses) {
+    swaggerDecorators.push(...config.responses.map((response) => {
+      if (!response.body) {
+        return ApiOkResponse({ status: response.status });
+      }
+
+      const clazz = createZodDto(response.body);
+      Object.defineProperty(clazz, 'name', { value: response.name })
+
+      return ApiResponse({
+        status: response.status,
+        type: clazz,
+      });
+    }));
   }
   if (config.body) {
     swaggerDecorators.push(
@@ -69,5 +80,3 @@ export const UseBorder = <
 export const UseWsBorder = () => {
   return applyDecorators(UsePipes(new BorderPatrolPipe({} as any)));
 };
-//
-//

--- a/src/border-patrol.interceptor.ts
+++ b/src/border-patrol.interceptor.ts
@@ -7,14 +7,14 @@ import {
 import { Observable, map } from "rxjs";
 import { ZodError, z } from "zod";
 import { BorderPatrolException } from "./border-patrol.exception";
-import { Banger, BorderConfiguration } from "./types";
+import { ApiResponseType, BorderConfiguration } from "./types";
 
 @Injectable()
 export class BorderPatrolInterceptor<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends Banger | undefined
+  TResponse extends ApiResponseType | undefined
 > implements NestInterceptor
 {
   constructor(

--- a/src/border-patrol.interceptor.ts
+++ b/src/border-patrol.interceptor.ts
@@ -1,22 +1,20 @@
 import {
   CallHandler,
   ExecutionContext,
-  HttpException,
-  HttpStatus,
   Injectable,
   NestInterceptor,
 } from "@nestjs/common";
+import { Observable, map } from "rxjs";
 import { ZodError, z } from "zod";
-import { catchError, map, Observable, throwError } from "rxjs";
-import { BorderConfiguration } from "./types";
 import { BorderPatrolException } from "./border-patrol.exception";
+import { Banger, BorderConfiguration } from "./types";
 
 @Injectable()
 export class BorderPatrolInterceptor<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends z.ZodSchema | undefined
+  TResponse extends Banger | undefined
 > implements NestInterceptor
 {
   constructor(
@@ -34,13 +32,33 @@ export class BorderPatrolInterceptor<
   ): Observable<any> {
     return next.handle().pipe(
       map((data) => {
-        if (!this.config.response) {
+        if (!this.config.responses) {
           return data;
         }
         // return this.config.response.parse(data);
         let parsedResponse: any;
         try {
-          parsedResponse = this.config.response.parse(data);
+          const statusCode = context
+            .switchToHttp()
+            .getResponse<Response>().status;
+
+          if (!this.config.responses || this.config.responses.length === 0) {
+            return data;
+          }
+
+          const schemaMatchingStatusCode = this.config.responses.find(
+            (r) => r.status === statusCode
+          );
+
+          if (!schemaMatchingStatusCode) {
+            throw new BorderPatrolException("response", new ZodError([]));
+          }
+
+          if (!schemaMatchingStatusCode.body) {
+            return data;
+          }
+
+          parsedResponse = schemaMatchingStatusCode.body.parse(data);
         } catch (err) {
           if (err instanceof ZodError) {
             throw new BorderPatrolException(

--- a/src/border-patrol.interceptor.ts
+++ b/src/border-patrol.interceptor.ts
@@ -8,13 +8,15 @@ import { Observable, map } from "rxjs";
 import { ZodError, z } from "zod";
 import { BorderPatrolException } from "./border-patrol.exception";
 import { ApiResponseType, BorderConfiguration } from "./types";
+import { ApiOperationOptions } from "@nestjs/swagger";
 
 @Injectable()
 export class BorderPatrolInterceptor<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends ApiResponseType | undefined
+  TResponse extends ApiResponseType | undefined,
+  TMetadata extends ApiOperationOptions | undefined
 > implements NestInterceptor
 {
   constructor(
@@ -22,7 +24,8 @@ export class BorderPatrolInterceptor<
       TBody,
       TQuery,
       TParams,
-      TResponse
+      TResponse,
+      TMetadata
     >
   ) {}
 

--- a/src/border-patrol.interceptor.ts
+++ b/src/border-patrol.interceptor.ts
@@ -40,7 +40,8 @@ export class BorderPatrolInterceptor<
         try {
           const statusCode = context
             .switchToHttp()
-            .getResponse<Response>().status;
+            .getResponse()
+            .statusCode;
 
           if (!this.config.responses || this.config.responses.length === 0) {
             return data;

--- a/src/border-patrol.pipe.ts
+++ b/src/border-patrol.pipe.ts
@@ -9,6 +9,7 @@ import {
 import { z, ZodError } from "zod";
 import { ApiResponseType, BorderConfiguration } from "./types";
 import { BorderPatrolException } from "./border-patrol.exception";
+import { ApiOperationOptions } from "@nestjs/swagger";
 
 class QueryOrParamsException extends Error {
   constructor(public readonly zodError: ZodError, public readonly key: string) {
@@ -21,7 +22,8 @@ export class BorderPatrolPipe<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends ApiResponseType | undefined
+  TResponse extends ApiResponseType | undefined,
+  TMetadata extends ApiOperationOptions | undefined
 > implements PipeTransform
 {
   constructor(
@@ -29,7 +31,8 @@ export class BorderPatrolPipe<
       TBody,
       TQuery,
       TParams,
-      TResponse
+      TResponse,
+      TMetadata
     >
   ) {}
 

--- a/src/border-patrol.pipe.ts
+++ b/src/border-patrol.pipe.ts
@@ -7,7 +7,7 @@ import {
   PipeTransform,
 } from "@nestjs/common";
 import { z, ZodError } from "zod";
-import { BorderConfiguration } from "./types";
+import { Banger, BorderConfiguration } from "./types";
 import { BorderPatrolException } from "./border-patrol.exception";
 
 class QueryOrParamsException extends Error {
@@ -21,7 +21,7 @@ export class BorderPatrolPipe<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends z.ZodSchema | undefined
+  TResponse extends Banger | undefined
 > implements PipeTransform
 {
   constructor(

--- a/src/border-patrol.pipe.ts
+++ b/src/border-patrol.pipe.ts
@@ -7,7 +7,7 @@ import {
   PipeTransform,
 } from "@nestjs/common";
 import { z, ZodError } from "zod";
-import { Banger, BorderConfiguration } from "./types";
+import { ApiResponseType, BorderConfiguration } from "./types";
 import { BorderPatrolException } from "./border-patrol.exception";
 
 class QueryOrParamsException extends Error {
@@ -21,7 +21,7 @@ export class BorderPatrolPipe<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends Banger | undefined
+  TResponse extends ApiResponseType | undefined
 > implements PipeTransform
 {
   constructor(

--- a/src/types/BorderConfiguration.ts
+++ b/src/types/BorderConfiguration.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-export type Banger = Array<{
+export type ApiResponseType = Array<{
   status: number;
   name: string;
   body: z.ZodSchema
@@ -10,7 +10,7 @@ export type BorderConfiguration<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends Banger | undefined
+  TResponse extends ApiResponseType | undefined
 > = {
   query: TQuery;
   params: TParams;
@@ -55,7 +55,7 @@ export type InferParams<TConfiguration> =
 
 export type InferResponse<TConfiguration> =
   TConfiguration extends BorderConfiguration<any, any, any, infer TResponse>
-    ? TResponse extends Banger
+    ? TResponse extends ApiResponseType
       ? TResponse[number] extends {
           body: z.ZodSchema;
         }

--- a/src/types/BorderConfiguration.ts
+++ b/src/types/BorderConfiguration.ts
@@ -1,3 +1,4 @@
+import { ApiOperationOptions } from "@nestjs/swagger";
 import { z } from "zod";
 
 export type ApiResponseType = Array<{
@@ -10,16 +11,18 @@ export type BorderConfiguration<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends ApiResponseType | undefined
+  TResponse extends ApiResponseType | undefined,
+  TMetadata extends ApiOperationOptions | undefined
 > = {
   query: TQuery;
   params: TParams;
   body: TBody;
   responses: TResponse;
+  meta: TMetadata;
 };
 
 export type InferBody<TConfiguration> =
-  TConfiguration extends BorderConfiguration<infer TBody, any, any, any>
+  TConfiguration extends BorderConfiguration<infer TBody, any, any, any, any>
     ? TBody extends z.ZodSchema
       ? z.infer<TBody>
       : TBody extends undefined
@@ -28,7 +31,7 @@ export type InferBody<TConfiguration> =
     : never;
 
 export type InferQuery<TConfiguration> =
-  TConfiguration extends BorderConfiguration<any, infer TQuery, any, any>
+  TConfiguration extends BorderConfiguration<any, infer TQuery, any, any, any>
     ? TQuery extends Record<string, z.ZodSchema | undefined>
       ? {
           [K in keyof TQuery]: TQuery[K] extends z.ZodSchema
@@ -41,7 +44,7 @@ export type InferQuery<TConfiguration> =
     : never;
 
 export type InferParams<TConfiguration> =
-  TConfiguration extends BorderConfiguration<any, any, infer TParams, any>
+  TConfiguration extends BorderConfiguration<any, any, infer TParams, any, any>
     ? TParams extends Record<string, z.ZodSchema | undefined>
       ? {
           [K in keyof TParams]: TParams[K] extends z.ZodSchema
@@ -54,7 +57,7 @@ export type InferParams<TConfiguration> =
     : never;
 
 export type InferResponse<TConfiguration> =
-  TConfiguration extends BorderConfiguration<any, any, any, infer TResponse>
+  TConfiguration extends BorderConfiguration<any, any, any, infer TResponse, any>
     ? TResponse extends ApiResponseType
       ? TResponse[number] extends {
           body: z.ZodSchema;

--- a/src/types/BorderConfiguration.ts
+++ b/src/types/BorderConfiguration.ts
@@ -1,15 +1,21 @@
 import { z } from "zod";
 
+export type Banger = Array<{
+  status: number;
+  name: string;
+  body: z.ZodSchema
+}>;
+
 export type BorderConfiguration<
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends z.ZodSchema | undefined
+  TResponse extends Banger | undefined
 > = {
   query: TQuery;
   params: TParams;
   body: TBody;
-  response: TResponse;
+  responses: TResponse;
 };
 
 export type InferBody<TConfiguration> =
@@ -49,10 +55,18 @@ export type InferParams<TConfiguration> =
 
 export type InferResponse<TConfiguration> =
   TConfiguration extends BorderConfiguration<any, any, any, infer TResponse>
-    ? TResponse extends z.ZodSchema
-      ? z.infer<TResponse>
-      : TResponse extends undefined
-      ? any
+    ? TResponse extends Banger
+      ? TResponse[number] extends {
+          body: z.ZodSchema;
+        }
+        ? {
+            [K in keyof TResponse]: TResponse[K] extends {
+              body: z.ZodSchema;
+            }
+              ? z.infer<TResponse[K]["body"]>
+              : never;
+          }[number]
+        : never
       : never
     : never;
 

--- a/src/utility/createBorder.ts
+++ b/src/utility/createBorder.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import {
-  Banger,
+  ApiResponseType,
   BorderConfiguration
 } from "../types/BorderConfiguration";
 
@@ -8,7 +8,7 @@ export const createBorder = <
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends Banger | undefined
+  TResponse extends ApiResponseType | undefined
 >({
   body,
   query,

--- a/src/utility/createBorder.ts
+++ b/src/utility/createBorder.ts
@@ -1,24 +1,27 @@
 import { z } from "zod";
-import { BorderConfiguration } from "../types/BorderConfiguration";
+import {
+  Banger,
+  BorderConfiguration
+} from "../types/BorderConfiguration";
 
 export const createBorder = <
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends z.ZodSchema | undefined
+  TResponse extends Banger | undefined
 >({
   body,
   query,
   params,
-  response,
+  responses,
 }: {
   body?: TBody;
   query?: TQuery;
   params?: TParams;
-  response?: TResponse;
+  responses?: TResponse;
 }): BorderConfiguration<TBody, TQuery, TParams, TResponse> => ({
   body: body as TBody,
   query: query as TQuery,
   params: params as TParams,
-  response: response as TResponse,
+  responses: responses as TResponse,
 });

--- a/src/utility/createBorder.ts
+++ b/src/utility/createBorder.ts
@@ -3,25 +3,30 @@ import {
   ApiResponseType,
   BorderConfiguration
 } from "../types/BorderConfiguration";
+import { ApiOperationOptions } from "@nestjs/swagger";
 
 export const createBorder = <
   TBody extends z.ZodSchema | undefined,
   TQuery extends Record<string, z.ZodSchema | undefined> | undefined,
   TParams extends Record<string, z.ZodSchema | undefined> | undefined,
-  TResponse extends ApiResponseType | undefined
+  TResponse extends ApiResponseType | undefined,
+  TMetadata extends ApiOperationOptions | undefined
 >({
   body,
   query,
   params,
   responses,
+  meta,
 }: {
   body?: TBody;
   query?: TQuery;
   params?: TParams;
   responses?: TResponse;
-}): BorderConfiguration<TBody, TQuery, TParams, TResponse> => ({
+  meta?: TMetadata;
+}): BorderConfiguration<TBody, TQuery, TParams, TResponse, TMetadata> => ({
   body: body as TBody,
   query: query as TQuery,
   params: params as TParams,
   responses: responses as TResponse,
+  meta: meta as TMetadata,
 });

--- a/src/utility/createWsBorder.ts
+++ b/src/utility/createWsBorder.ts
@@ -7,5 +7,5 @@ export const createWsBorder = <TBody extends z.ZodSchema>(
   body: schema,
   query: undefined,
   params: undefined,
-  response: undefined,
+  responses: undefined,
 });

--- a/src/utility/createWsBorder.ts
+++ b/src/utility/createWsBorder.ts
@@ -3,9 +3,10 @@ import { BorderConfiguration } from "../types/BorderConfiguration";
 
 export const createWsBorder = <TBody extends z.ZodSchema>(
   schema: TBody
-): BorderConfiguration<TBody, undefined, undefined, undefined> => ({
+): BorderConfiguration<TBody, undefined, undefined, undefined, undefined> => ({
   body: schema,
   query: undefined,
   params: undefined,
   responses: undefined,
+  meta: undefined,
 });


### PR DESCRIPTION
RFC: Multiple responses and better metadata support (very breaking)

- Multiple response support.
- Better metadata support.
- Generation of OpenAPI models.

1. New `meta` property on `createBorder()`.

```typescript
const MyBorder = createBorder({
   // ... rest of border
  meta: {
    summary: "My summary of the route",
  }
})
```

If supplied, this will push a `@ApiOperation()` decorator onto the decorator stack. Type of parameter is `ApiOperationOptions` from `@nestjs/swagger`.

2. `response` is now `responses`. Takes an array of this shape:
```typescript
const MyBorder = createBorder({
   // ... rest of border
  responses: [
    {
      name: "Name of component in OpenAPI."
      status: 201
      body: z.object({
        yourResponseTypes: z.string()
      })
    },
    {
      name: "Name of component 2 in OpenAPI."
      status: 404
      body: z.object({
        veryError: MyCustomErrorSchema
      })
    }
  ]
})
```

Resulting type when using `InferResponse<typeof MyBorder>`:

```typescript
{ 
  yourResponseTypes: string
} | {
  veryError: MyCustomError
}
```

Schema that has matching code to the controller methods return status is used for validation when returning data.

Pseudocode:

```typescript
const statusCode = getStatusCodeFromResponse();

if (!responsesToValidate) {
  return data; // No validation
}

const schemaMatchingStatusCode = findSchemaMatchingCode(responseSchemasFromBorder);

if (!schemaMatchingStatusCode) {
  throw Error();
}

if (!bodySchemaInResponse(schemaMatchingStatusCode)) {
  return data; // No validation
}

parsedResponse = schemaMatchingStatusCode.body.parse(data);
```